### PR TITLE
Add couple extensions to `.summoner.toml`

### DIFF
--- a/.summoner.toml
+++ b/.summoner.toml
@@ -12,6 +12,8 @@ stylish.url = "https://raw.githubusercontent.com/kowainik/org/master/.stylish-ha
 extensions = [ "ConstraintKinds"
              , "DeriveGeneric"
              , "GeneralizedNewtypeDeriving"
+             , "InstanceSigs"
+             , "KindSignatures"
              , "LambdaCase"
              , "OverloadedStrings"
              , "RecordWildCards"


### PR DESCRIPTION
Just added couple extensions that usually allow to annotate code with more type signatures making it more readable. I find myself using those extensions quite often. Don't think having such extensions in the `default-extensions` section can harm somebody.