### PR TITLE
Use more generic files way in .summoner.toml

### DIFF
--- a/.summoner.toml
+++ b/.summoner.toml
@@ -8,7 +8,15 @@ github   = true
 travis   = true
 
 ghcVersions = ["8.2.2", "8.4.4"]
-stylish.url = "https://raw.githubusercontent.com/kowainik/org/master/.stylish-haskell.yaml"
+
+files =
+    [ { path = ".stylish-haskell.yaml"
+      , url  = "https://raw.githubusercontent.com/kowainik/org/master/.stylish-haskell.yaml"
+      }
+    , { path = ".github/CODEOWNERS"
+      , url  = "https://raw.githubusercontent.com/kowainik/org/master/.github/CODEOWNERS"
+      }
+    ]
 
 extensions = [ "ConstraintKinds"
              , "DeriveGeneric"


### PR DESCRIPTION
For now, this is just an example of how more generic specification of extra files will look like in new `summoner`.